### PR TITLE
Don't use win32api external module

### DIFF
--- a/src/kolibri_tools/utils.py
+++ b/src/kolibri_tools/utils.py
@@ -1,16 +1,27 @@
 import json
 import logging
 import os
+import string
 from collections import Mapping
+from ctypes import windll
 
 from config import KOLIBRI_PORT
 
 
+def get_drives():
+    drives = []
+    bitmask = windll.kernel32.GetLogicalDrives()
+    for letter in string.ascii_uppercase:
+        if bitmask & 1:
+            drives.append(f'{letter}:\\')
+        bitmask >>= 1
+
+    return drives
+
+
 def get_key_kolibri_data():
-    import win32api
     folder_name = 'KOLIBRI_DATA'
-    drives = win32api.GetLogicalDriveStrings().split('\x00')
-    for drive in drives:
+    for drive in get_drives():
         data_folder_name = os.path.join(drive, folder_name)
         if drive and os.path.exists(data_folder_name):
             return data_folder_name


### PR DESCRIPTION
Use base python ctypes.windll to discover USB drives instead of the
external library win32api.

https://phabricator.endlessm.com/T31907