### PR TITLE
Build with Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install requirements
         run: |


### PR DESCRIPTION
Kolibri's C extensions are available for Python 3.4, 3.5,
3.6, and 3.7; cefpython is available for Python 3.7, 3.8,
and 3.9.

https://phabricator.endlessm.com/T31999