### PR TITLE
electron: Increase kolibri ping timeout

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -17,7 +17,7 @@ if (require('electron-squirrel-startup')) { // eslint-disable-line global-requir
 
 const NULL_PLUGIN_VERSION = '0';
 const KOLIBRI = 'http://localhost:5000';
-let pingTimeout = 20;
+let pingTimeout = 40;
 let mainWindow = null;
 let loadRetries = 0;
 let timeSpent = 0;


### PR DESCRIPTION
It takes some time to launch the kolibri backend and when the database
is larger the time is longer, so we need to increase the timeout to
avoid reloading the kolibri service when it takes a bit more time.

https://phabricator.endlessm.com/T32261