### PR TITLE
CI: Create a ZIP file before upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,11 @@ jobs:
         run: |
           mv kolibri-electron/out/kolibri-electron-win32-x64 kolibri-windows
 
+      - name: Compress
+        run: Compress-Archive -Path kolibri-windows\* -DestinationPath kolibri-windows.zip
+        shell: pwsh
+
       - uses: actions/upload-artifact@v2
         with:
-          name: "kolibri-windows"
-          path: "kolibri-windows"
+          name: "kolibri-windows.zip"
+          path: "kolibri-windows.zip"


### PR DESCRIPTION
This will decrease the build time because it just does one HTTP request
to the artifact API.

https://github.com/actions/upload-artifact#too-many-uploads-resulting-in-429-responses

https://phabricator.endlessm.com/T32413