### PR TITLE
Pin kolibri-zim-plugin to 1.1.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Add kolibri_zim_plugin to Kolibri's dist packages
         run: |
-          pip install kolibri-zim-plugin --target="src\kolibri\dist"
+          pip install kolibri-zim-plugin==1.1.2 --target="src\kolibri\dist"
 
       - name : Patch Kolibri's server code to avoid Windows firewall prompts
         run: |


### PR DESCRIPTION
The newest version of the plugin introduces a change which is
incompatible with kolibri 0.14.

https://phabricator.endlessm.com/T32766