### PR TITLE
Build pyinstaller from sources

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,26 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-win.txt
 
+
+      - name: Checkout pyinstaller
+        uses: actions/checkout@v2
+        with:
+          repository: pyinstaller/pyinstaller
+          path: pyinstaller
+          ref: v4.9
+
+      - name: Build pyinstaller bootloader
+        run: |
+          python waf all --target-arch=32bit
+        working-directory: pyinstaller/bootloader
+
+      - name: Install pyinstaller
+        run: |
+          python setup.py install
+        working-directory: pyinstaller
+        env:
+          PYINSTALLER_COMPILE_BOOTLOADER: 1
+
       - name: Prep kolibri dist
         run: |
           python kapew.py prep-kolibri-dist --skip-preseed --exclude-prereleases

--- a/requirements-win.in
+++ b/requirements-win.in
@@ -1,1 +1,0 @@
-PyInstaller==3.6

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -10,8 +10,6 @@ future==0.18.2
     # via pefile
 pefile==2021.5.24
     # via pyinstaller
-pyinstaller==3.6
-    # via -r .\requirements-win.in
 pywin32-ctypes==0.2.0
     # via pyinstaller
 


### PR DESCRIPTION
The pyinstaller from pip produces a binary that's suspicious for some antivirus, this PR builds from source code to workaround this problem.

https://python.plainenglish.io/python-pyinstaller-exe-false-positive-as-trojan-virus-resolved-abd13cb0f314

https://phabricator.endlessm.com/T33176