### PR TITLE
Bringing in Windows package manifest and pipeline

### DIFF
--- a/.buildkite_win/appxmanifest.xml
+++ b/.buildkite_win/appxmanifest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10">
+  <Identity Name="EndlessOSFoundation.EndlessKey.app" Version="0.1.10.1" Publisher="CN=Endless OS Foundation LLC, O=Endless OS Foundation LLC, L=San Francisco, S=California, C=US, SERIALNUMBER=7858239, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US" ProcessorArchitecture="x64" />
+  <Properties>
+    <DisplayName>Endless Key app</DisplayName>
+    <PublisherDisplayName>Endless OS Foundation LLC</PublisherDisplayName>
+    <Description>Endless Key app</Description>
+    <Logo>resources/app/src/icon.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14316.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust"/>
+  </Capabilities>
+  <Applications>
+    <Application Id="endlesskeyapp" Executable="kolibri-electron.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap3:VisualElements DisplayName="Endless Key app" Description="Endless Key app" Square150x150Logo="resources/app/src/icon.png" Square44x44Logo="resources/app/src/icon.png" BackgroundColor="#FFFFFF" />
+      <Extensions>
+        <uap3:Extension Category="windows.appExecutionAlias" EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="kolibri-electron.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+</Package>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,13 +87,23 @@ jobs:
         run: Compress-Archive -Path kolibri-windows\* -DestinationPath kolibri-windows.zip
         shell: pwsh
 
+      - name: Packaging
+        run: |
+          cp .buildkite_win/appxmanifest.xml kolibri-windows/
+          & "${Env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\makeappx.exe" pack /d kolibri-windows /p endlesskeyapp.appx
+
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: kolibri-windows.zip
+          files: kolibri-windows.zip endlesskeyapp.appx
 
       - uses: actions/upload-artifact@v2
         with:
           name: "kolibri-windows.zip"
           path: "kolibri-windows.zip"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "endlesskeyapp.appx"
+          path: "endlesskeyapp.appx"


### PR DESCRIPTION
Bring the appxmanifest.xml for APPX/MSIX packaging. Also, add the steps
into the CI pipeline to build the package and upload the artifact.

The first 3 fields of Identity's Version in appxmanifest.xml should be
same as the release version. The fourth field could be build times, or
anything else.

https://phabricator.endlessm.com/T33442