### PR TITLE
Make kolibri-electron app runnable without KEY

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           pip install kolibri-zim-plugin --target="src\kolibri\dist"
 
+      - name: Add kolibri_explore_plugin to Kolibri's dist packages
+        run: |
+          pip install kolibri-explore-plugin --target="src\kolibri\dist"
+
       - name : Patch Kolibri's server code to avoid Windows firewall prompts
         run: |
           C:\msys64\usr\bin\patch.exe src\kolibri\utils\server.py patches\kolibri-utils-server.diff

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,10 @@ jobs:
         run: |
           python kapew.py prep-kolibri-dist --skip-preseed --exclude-prereleases
 
+      - name: Add kolibri_zim_plugin to Kolibri's dist packages
+        run: |
+          pip install kolibri-zim-plugin --target="src\kolibri\dist"
+
       - name : Patch Kolibri's server code to avoid Windows firewall prompts
         run: |
           C:\msys64\usr\bin\patch.exe src\kolibri\utils\server.py patches\kolibri-utils-server.diff

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,16 @@ jobs:
         run: |
           pip install kolibri-explore-plugin --target="src\kolibri\dist"
 
+      - uses: robinraju/release-downloader@v1.3
+        with:
+          repository: "endlessm/kolibri-explore-plugin"
+          latest: true
+          fileName: "apps-bundle.zip"
+
+      - name: Add apps-bundle to Kolibri's dist packages
+        run: |
+          7z x apps-bundle.zip -osrc/apps-bundle
+
       - name : Patch Kolibri's server code to avoid Windows firewall prompts
         run: |
           C:\msys64\usr\bin\patch.exe src\kolibri\utils\server.py patches\kolibri-utils-server.diff
@@ -90,6 +100,7 @@ jobs:
 
           mv src/kolibri dist/win/Kolibri
           mv dist/win/Kolibri kolibri-windows/resources/app/src/
+          mv src/apps-bundle kolibri-windows/resources/app/src/
 
       - name: Compress
         run: Compress-Archive -Path kolibri-windows\* -DestinationPath kolibri-windows.zip

--- a/kolibri-electron/src/automatic_provision.json
+++ b/kolibri-electron/src/automatic_provision.json
@@ -1,0 +1,25 @@
+{
+    "facility_name": "Endless",
+    "preset": "nonformal",
+    "facility_settings": {
+        "learner_can_edit_username": true,
+        "learner_can_edit_name": true,
+        "learner_can_edit_password": true,
+        "learner_can_sign_up": true,
+        "learner_can_delete_account": true,
+        "show_download_button_in_learn": true
+    },
+    "device_settings": {
+        "language_id": "en",
+        "landing_page": "learn",
+        "allow_guest_access": true,
+        "allow_peer_unlisted_channel_import": true,
+        "allow_learner_unassigned_resource_access": true,
+        "name": "Endless Learning",
+        "allow_other_browsers_to_connect": true
+    },
+    "superuser": {
+        "username": "admin",
+        "password": "admin"
+    }
+}

--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -190,7 +190,7 @@ const waitForKolibriUp = () => {
   }
 
   http.get(`${KOLIBRI}/api/public/info`, (response) => {
-    mainWindow.loadURL(KOLIBRI);
+    mainWindow.loadURL(`${KOLIBRI}/explore`);
     updateVersion();
   }).on("error", (error) => {
     console.log("Error: " + error.message);

--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -29,6 +29,7 @@ let django = null;
 let KOLIBRI_HOME_TEMPLATE = '';
 let KOLIBRI_EXTENSIONS = path.join(__dirname, 'Kolibri', 'kolibri', 'dist');
 let KOLIBRI_HOME = path.join(os.homedir(), `.endless-key-${KEY_VERSION}`);
+const AUTOPROVISION_FILE = path.join(__dirname, 'automatic_provision.json');
 
 function removePidFile() {
   const pidFile = path.join(KOLIBRI_HOME, 'server.pid');
@@ -65,8 +66,15 @@ async function getEndlessKeyDataPath() {
 
 async function loadKolibriEnv() {
   const keyData = await getEndlessKeyDataPath();
+  env.KOLIBRI_HOME = KOLIBRI_HOME;
 
   if (!keyData) {
+    // Copy the provision file because Kolibri removes after applying
+    const removable_provision_file = path.join(__dirname, 'provision.json')
+    if (!fs.existsSync(removable_provision_file)) {
+      await fsExtra.copy(AUTOPROVISION_FILE, removable_provision_file);
+    }
+    env.KOLIBRI_AUTOMATIC_PROVISION_FILE = removable_provision_file;
     env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
 
     return false;
@@ -79,7 +87,6 @@ async function loadKolibriEnv() {
 
   env.KOLIBRI_CONTENT_FALLBACK_DIRS = path.join(keyData, 'content');
   env.PYTHONPATH = KOLIBRI_EXTENSIONS;
-  env.KOLIBRI_HOME = KOLIBRI_HOME;
 
   return true;
 }

--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -219,14 +219,14 @@ async function createWindow() {
   await mainWindow.loadFile(await getLoadingScreen());
 
   if (!isDataAvailable) {
-    mainWindow.webContents.executeJavaScript('show_error()', true);
+    console.log('No Endless Key data found. Loading default Kolibri');
   } else {
     const firstLaunch = await checkVersion();
     if (firstLaunch) {
       mainWindow.webContents.executeJavaScript('firstLaunch()', true);
     }
-    waitForKolibriUp(mainWindow);
   }
+  waitForKolibriUp(mainWindow);
 
   return isDataAvailable;
 };
@@ -257,9 +257,7 @@ const runKolibri = () => {
 app.on('ready', () => {
   createWindow()
     .then((isDataAvailable) => {
-      if (isDataAvailable) {
-        runKolibri();
-      }
+      runKolibri();
     });
 });
 

--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -67,6 +67,8 @@ async function loadKolibriEnv() {
   const keyData = await getEndlessKeyDataPath();
 
   if (!keyData) {
+    env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
+
     return false;
   }
 

--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -27,7 +27,7 @@ let maxRetries = 3;
 let django = null;
 
 let KOLIBRI_HOME_TEMPLATE = '';
-let KOLIBRI_EXTENSIONS = '';
+let KOLIBRI_EXTENSIONS = path.join(__dirname, 'Kolibri', 'kolibri', 'dist');
 let KOLIBRI_HOME = path.join(os.homedir(), `.endless-key-${KEY_VERSION}`);
 
 function removePidFile() {
@@ -72,7 +72,9 @@ async function loadKolibriEnv() {
     return false;
   }
 
-  KOLIBRI_EXTENSIONS = path.join(keyData, 'extensions');
+  if (fs.existsSync(path.join(keyData, 'extensions'))) {
+    KOLIBRI_EXTENSIONS = path.join(keyData, 'extensions');
+  }
   KOLIBRI_HOME_TEMPLATE = path.join(keyData, 'preseeded_kolibri_home');
 
   env.KOLIBRI_CONTENT_FALLBACK_DIRS = path.join(keyData, 'content');
@@ -142,7 +144,10 @@ async function checkVersion() {
   if (kolibriHomeVersion < pluginVersion) {
     console.log('Newer version, replace the .endless-key directory and cleaning cache');
     await fsExtra.remove(KOLIBRI_HOME);
-    await fsExtra.copy(KOLIBRI_HOME_TEMPLATE, KOLIBRI_HOME);
+
+    if (fs.existsSync(KOLIBRI_HOME_TEMPLATE)) {
+      await fsExtra.copy(KOLIBRI_HOME_TEMPLATE, KOLIBRI_HOME);
+    }
     mainWindow.webContents.session.clearCache();
     return true;
   }

--- a/src/kolibri_tools/utils.py
+++ b/src/kolibri_tools/utils.py
@@ -1,21 +1,73 @@
+import importlib
 import json
 import logging
 import os
 from collections import Mapping
 
 from config import KOLIBRI_PORT, KOLIBRI_ZIP_PORT
+from kolibri.plugins import config as plugins_config
+from kolibri.plugins.utils import enable_plugin, disable_plugin
+from kolibri.plugins.registry import registered_plugins
+
+
+# These Kolibri plugins conflict with the plugins listed in REQUIRED_PLUGINS
+# or OPTIONAL_PLUGINS:
+DISABLED_PLUGINS = [
+    "kolibri.plugins.learn",
+]
+
+# These Kolibri plugins must be enabled for the application to function
+# correctly:
+REQUIRED_PLUGINS = [
+    "kolibri.plugins.app",
+]
+
+# These Kolibri plugins will be dynamically enabled if they are available:
+OPTIONAL_PLUGINS = [
+    "kolibri_explore_plugin",
+    "kolibri_zim_plugin",
+]
+
+
+def _disable_kolibri_plugin(plugin_name: str) -> bool:
+    if plugin_name in plugins_config.ACTIVE_PLUGINS:
+        logging.info(f"Disabling plugin {plugin_name}")
+        disable_plugin(plugin_name)
+
+    return True
+
+
+def _enable_kolibri_plugin(plugin_name: str, optional=False) -> bool:
+    if optional and not importlib.util.find_spec(plugin_name):
+        return False
+
+    if plugin_name not in plugins_config.ACTIVE_PLUGINS:
+        logging.info(f"Enabling plugin {plugin_name}")
+        registered_plugins.register_plugins([plugin_name])
+        enable_plugin(plugin_name)
+
+    return True
+
+
+def initialize_plugins():
+    for plugin_name in DISABLED_PLUGINS:
+        _disable_kolibri_plugin(plugin_name)
+
+    for plugin_name in REQUIRED_PLUGINS:
+        _enable_kolibri_plugin(plugin_name)
+
+    for plugin_name in OPTIONAL_PLUGINS:
+        _enable_kolibri_plugin(plugin_name, optional=True)
 
 
 def start_kolibri_server():
     from kolibri.utils.cli import initialize, setup_logging, start
-    from kolibri.plugins.registry import registered_plugins
-
-    registered_plugins.register_plugins(['kolibri.plugins.app'])
 
     logging.info("Starting server...")
     setup_logging(debug=False)
     initialize()
     automatic_provisiondevice()
+
     start.callback(KOLIBRI_PORT, zip_port=KOLIBRI_ZIP_PORT, background=False)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import sys
 from functools import partial
 
 from config import KOLIBRI_PORT
+from kolibri_tools.utils import initialize_plugins
 from kolibri_tools.utils import start_kolibri_server
 
 
@@ -102,6 +103,7 @@ class Application:
         os.environ["KOLIBRI_HTTP_PORT"] = str(self.port)
 
         logging.info("Preparing to start Kolibri server...")
+        initialize_plugins()
         start_kolibri_server()
 
 


### PR DESCRIPTION
This PR makes the windows app usable without the Endless Key, but it's compatible, so if the content is not detected it uses the inside configuration.

https://phabricator.endlessm.com/T33457