### PR TITLE
electron: Fallback to default AUTOPROVISION_FILE

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -70,11 +70,15 @@ async function loadKolibriEnv() {
 
   if (!keyData) {
     // Copy the provision file because Kolibri removes after applying
-    const removable_provision_file = path.join(__dirname, 'provision.json')
-    if (!fs.existsSync(removable_provision_file)) {
-      await fsExtra.copy(AUTOPROVISION_FILE, removable_provision_file);
+    let provision_file = path.join(__dirname, 'provision.json');
+    if (!fs.existsSync(provision_file)) {
+      try {
+        fsExtra.copySync(AUTOPROVISION_FILE, provision_file);
+      } catch {
+        provision_file = AUTOPROVISION_FILE;
+      }
     }
-    env.KOLIBRI_AUTOMATIC_PROVISION_FILE = removable_provision_file;
+    env.KOLIBRI_AUTOMATIC_PROVISION_FILE = provision_file;
     env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
 
     return false;


### PR DESCRIPTION
If the copy of the provision file fails, the app will use the default
provision file. This will make the app working when installed from the
appx and also when it's used from the Endless Key as an standalone.

https://phabricator.endlessm.com/T33467