### PR TITLE
appx: Build as x86 architecture for both 32 and 64 bits Windows

### DIFF
--- a/.buildkite_win/appxmanifest.xml
+++ b/.buildkite_win/appxmanifest.xml
@@ -8,7 +8,7 @@
     Name="EndlessOSFoundation.EndlessKey"
     Version="1.0.0.0"
     Publisher="CN=4B001A25-B854-44D9-BAD3-8AD7FC7A8761"
-    ProcessorArchitecture="x64" />
+    ProcessorArchitecture="x86" />
   <Properties>
     <DisplayName>Endless Key</DisplayName>
     <PublisherDisplayName>Endless OS Foundation</PublisherDisplayName>


### PR DESCRIPTION
Since the executable binaries are build as 32 bits application, let's
package Endless Key as x86 architecture directly for both 32 and 64 bits
Windows compatibility.

https://phabricator.endlessm.com/T33473