### PR TITLE
CI: Update the version in manifest with tag and build number

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # Need to fetch everything so that 'git describe' can see the tags
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -111,7 +114,17 @@ jobs:
 
       - name: Packaging
         run: |
-          cp .buildkite_win/appxmanifest.xml kolibri-windows/
+          $describe = (git describe --always --tags --match 'v*')
+          $ver_arr = $describe -split '[-v]'
+          $ver_str = $ver_arr[1] + "." + $ver_arr[2]
+
+          echo "Set package's version as $ver_str"
+          $src = ".buildkite_win/appxmanifest.xml"
+          $dst = "kolibri-windows/appxmanifest.xml"
+          [xml]$xmlDoc = Get-Content $src
+          $xmlDoc.Package.Identity.Version = $ver_str
+          $xmlDoc.Save($dst)
+
           Copy-Item -Path ".buildkite_win/assets" -Destination "kolibri-windows/" -recurse
           & "${Env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\makeappx.exe" pack /d kolibri-windows /p endlesskey.appx
 


### PR DESCRIPTION
To let application rolling update work correctly, the package's version
number should be increased. This patch sets the version in the
appxmanifest.xml by following the tag's version (Major.Minor.Build) with
build number as the Revision.

https://phabricator.endlessm.com/T33501