### PR TITLE
CI: Force long git description format for both tag and none tag commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Packaging
         run: |
-          $describe = (git describe --always --tags --match 'v*')
+          $describe = (git describe --always --tags --long --match 'v*')
           $ver_arr = $describe -split '[-v]'
           $ver_str = $ver_arr[1] + "." + $ver_arr[2]
 


### PR DESCRIPTION
This patch fixes the packaging failure when tag by always having long
git description format.

https://phabricator.endlessm.com/T33501