### PR TITLE
electron: Set KOLIBRI_APPS_BUNDLE_PATH always

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -73,6 +73,7 @@ async function loadKolibriEnv() {
   const keyData = await getEndlessKeyDataPath();
   env.KOLIBRI_HOME = KOLIBRI_HOME;
   env.PYTHONPATH = KOLIBRI_EXTENSIONS;
+  env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
 
   if (!keyData) {
     // Copy the provision file because Kolibri removes after applying
@@ -85,17 +86,10 @@ async function loadKolibriEnv() {
       }
     }
     env.KOLIBRI_AUTOMATIC_PROVISION_FILE = provision_file;
-    env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
-
     return false;
   }
 
-  if (fs.existsSync(path.join(keyData, 'extensions'))) {
-    KOLIBRI_EXTENSIONS = path.join(keyData, 'extensions');
-    env.PYTHONPATH = KOLIBRI_EXTENSIONS;
-  }
   KOLIBRI_HOME_TEMPLATE = path.join(keyData, 'preseeded_kolibri_home');
-
   env.KOLIBRI_CONTENT_FALLBACK_DIRS = path.join(keyData, 'content');
 
   // Lock USB


### PR DESCRIPTION
The apps-bundle is now in the application, so it'll be used always this
path.

https://phabricator.endlessm.com/T33534