### PR TITLE
CI: Redirect the Application Payload to Package Flight on Microsoft store

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,7 +209,7 @@ jobs:
           repository: microsoft/StoreBroker
           path: StoreBroker
 
-      - name: Create and push the Application Payload for Microsoft store
+      - name: Create and push the Application Payload to Package Flight on Microsoft store
         if: startsWith(github.ref, 'refs/tags/')
         shell: pwsh
         env:
@@ -256,8 +256,12 @@ jobs:
             -OutName endlesskey `
             -Verbose
 
-          $submissionId, $submissionUrl = Update-ApplicationSubmission `
+          $FLIGHT_NAME = "Alpha Test Flight"
+          $flight = Get-ApplicationFlights -AppId $APP_ID | Where-Object { $_.friendlyName -eq $FLIGHT_NAME }
+
+          Update-ApplicationFlightSubmission `
             -AppId $APP_ID `
+            -FlightId $flight.flightId `
             -SubmissionDataPath "$SubmissionRoot/endlesskey.json" `
             -PackagePath "$SubmissionRoot/endlesskey.zip" `
             -ReplacePackages `


### PR DESCRIPTION
To have stable and alpha/beta releases at the same time, push the
Application Payload to Package Flight on Microsoft store as the alpha
release. Normal submission can choose the pacakge from the flight for
stable release on the Microsoft store management web page.

https://phabricator.endlessm.com/T33559