### PR TITLE
CI: Sign the binaries for Endless Key USB image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,6 +206,64 @@ jobs:
             endlesskey.appx
 
 
+  sign_binaries_for_EK_USB_image:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+
+    steps:
+      - name: Download the kolibri-windows.zip
+        uses: actions/download-artifact@v3
+        with:
+          name: kolibri-windows.zip
+
+      - name: Sign the binaries
+        id: sing_binaries
+        shell: pwsh
+        env:
+          SIGNPATH_ORG_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          SIGNPATH_USER_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          Expand-Archive kolibri-windows.zip -DestinationPath kolibri-windows
+
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module -name SignPath
+          Submit-SigningRequest `
+            -CIUserToken $env:SIGNPATH_USER_TOKEN `
+            -OrganizationId $env:SIGNPATH_ORG_ID `
+            -ProjectSlug Endless_Apps `
+            -SigningPolicySlug Endless_Apps_Signing_for_Endless_USB_Key `
+            -ArtifactConfigurationSlug Binaries_for_Endless_USB_Key `
+            -InputArtifactPath kolibri-windows/kolibri-electron.exe `
+            -OutputArtifactPath kolibri-electron.signed.exe `
+            -WaitForCompletion
+
+          Submit-SigningRequest `
+            -CIUserToken $env:SIGNPATH_USER_TOKEN `
+            -OrganizationId $env:SIGNPATH_ORG_ID `
+            -ProjectSlug Endless_Apps `
+            -SigningPolicySlug Endless_Apps_Signing_for_Endless_USB_Key `
+            -ArtifactConfigurationSlug Binaries_for_Endless_USB_Key `
+            -InputArtifactPath kolibri-windows/resources/app/src/Kolibri/Kolibri.exe `
+            -OutputArtifactPath Kolibri.signed.exe `
+            -WaitForCompletion
+
+          mv kolibri-electron.signed.exe kolibri-windows/kolibri-electron.exe
+          mv Kolibri.signed.exe kolibri-windows/resources/app/src/Kolibri/Kolibri.exe
+
+          rm kolibri-windows.zip
+
+      - name: Compress
+        run: Compress-Archive -Path kolibri-windows\* -DestinationPath kolibri-windows.zip
+        shell: pwsh
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: steps.sing_binaries.outcome == 'success'
+        with:
+          files: kolibri-windows.zip
+
+
   push_to_MS_store:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Need to fetch everything so that 'git describe' can see the tags
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -157,8 +154,27 @@ jobs:
           name: "kolibri-windows.zip"
           path: "kolibri-windows.zip"
 
+
+  package:
+    needs: build
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch everything so that 'git describe' can see the tags
+          fetch-depth: 0
+
+      - name: Download the kolibri-windows.zip
+        uses: actions/download-artifact@v3
+        with:
+          name: kolibri-windows.zip
+
       - name: Packaging
         run: |
+          Expand-Archive kolibri-windows.zip -DestinationPath kolibri-windows
+
           $describe = (git describe --always --tags --long --match 'v*')
           $ver_arr = $describe -split '[-v]'
           $ver_str = $ver_arr[1] + "." + $ver_arr[2]
@@ -196,14 +212,6 @@ jobs:
         with:
           name: "endlesskey.selfsigned.appx"
           path: "endlesskey.selfsigned.appx"
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            kolibri-windows.zip
-            endlesskey.appx
 
 
   sign_binaries_for_EK_USB_image:
@@ -265,7 +273,7 @@ jobs:
 
 
   push_to_MS_store:
-    needs: build
+    needs: package
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,15 +205,25 @@ jobs:
             kolibri-windows.zip
             endlesskey.appx
 
+
+  push_to_MS_store:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+
+    steps:
+      - name: Download the package
+        uses: actions/download-artifact@v3
+        with:
+          name: endlesskey.appx
+
       - name: Checkout StoreBroker
         uses: actions/checkout@v3
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           repository: microsoft/StoreBroker
           path: StoreBroker
 
       - name: Create and push the Application Payload to Package Flight on Microsoft store
-        if: startsWith(github.ref, 'refs/tags/')
         shell: pwsh
         env:
           MS_TENANT_ID: ${{ secrets.MSPARTNER_TENANTID }}


### PR DESCRIPTION
To sign the binaries for Endless Key USB image, split package and push to Microsoft store as anther two jobs. Also, add a new job to sign binaries with SignPath service.

https://phabricator.endlessm.com/T33599