### PR TITLE
Use kolibri-zim-plugin[full]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Add kolibri_zim_plugin to Kolibri's dist packages
         run: |
-          pip install kolibri-zim-plugin --target="src\kolibri\dist"
+          pip install kolibri-zim-plugin[full] --target="src\kolibri\dist"
 
       - name: Add kolibri_explore_plugin to Kolibri's dist packages
         run: |


### PR DESCRIPTION
With the newest version of kolibri-zim-plugin (endlessm/kolibri-zim-plugin#17), lxml is optional.

https://phabricator.endlessm.com/T33395