### PR TITLE
CI: Force build when the tag.yml action is triggered

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  create:
   push:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  weekly_tag:
+  tag:
     runs-on: windows-latest
 
     steps:
@@ -40,3 +40,7 @@ jobs:
           version: ${{ steps.have_new_tag_string.outputs.tag_string }}
           message: "Release ${{ steps.have_new_tag_string.outputs.tag_string }}"
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_for_tag:
+    needs: tag
+    uses: .github/workflows/main.yml


### PR DESCRIPTION
Current tag action does not trigger the build process in main.yml. Have
a build_for_tag job using the main.yml to force the build.

https://phabricator.endlessm.com/T33610