### PR TITLE
CI: Remove the kolibri binaries for file replacement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,6 +255,8 @@ jobs:
             -OutputArtifactPath Kolibri.signed.exe `
             -WaitForCompletion
 
+          rm kolibri-windows/kolibri-electron.exe
+          rm kolibri-windows/resources/app/src/Kolibri/Kolibri.exe
           mv kolibri-electron.signed.exe kolibri-windows/kolibri-electron.exe
           mv Kolibri.signed.exe kolibri-windows/resources/app/src/Kolibri/Kolibri.exe
 


### PR DESCRIPTION
The PowerShell of GitHub CI action cannot replace the files with mv
command directly. So, remove the original files first.

https://phabricator.endlessm.com/T33599