### PR TITLE
CI: Fix the tag.yml does not release issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
   workflow_call:
+    inputs:
+      is_at_tag:
+        description: 'The git HEAD is at a tag, or not'
+        default: false
+        required: false
+        type: boolean
   workflow_dispatch:
 
 jobs:
@@ -206,7 +212,7 @@ jobs:
 
       - name: Sign artifact for testing
         id: sign_for_testing
-        if: startsWith(github.ref, 'refs/tags/') == false
+        if: (startsWith(github.ref, 'refs/tags/') == false) && ( inputs.is_at_tag == false )
         shell: pwsh
         env:
           SIGN_PHRASE: ${{ secrets.SELFSIGN_PHRASE }}
@@ -225,7 +231,7 @@ jobs:
 
   sign_binaries_for_EK_USB_image:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.is_at_tag
     runs-on: windows-latest
 
     steps:
@@ -285,7 +291,7 @@ jobs:
 
   push_to_MS_store:
     needs: package
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.is_at_tag
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -47,3 +47,5 @@ jobs:
     needs: tag
     if: needs.tag.outputs.tag_string
     uses: ./.github/workflows/main.yml
+    with:
+      is_at_tag: ${{ needs.tag.outputs.tag_string }} != ""


### PR DESCRIPTION
When tag.yml is triggered on branch master, the git reference has not
been at a tag. So, when the main.yml is used by tag.yml, the git
refernece has not been at a tag as well. This makes the release
condition check startsWith(github.ref, 'refs/tags/') becomes failed.

Therefore, pass argument tag_name into main.yml to know git HEAD is on a
tag, or not.

https://phabricator.endlessm.com/T33610