### PR TITLE
CI: Pass the latest tag name from tag.yml to main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,11 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      is_at_tag:
-        description: 'The git HEAD is at a tag, or not'
-        default: false
-        required: false
-        type: boolean
+      tag_name:
+        description: 'The git tag name for release'
+        default: ''
+        required: true
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -212,7 +212,7 @@ jobs:
 
       - name: Sign artifact for testing
         id: sign_for_testing
-        if: (startsWith(github.ref, 'refs/tags/') == false) && ( inputs.is_at_tag == false )
+        if: (startsWith(github.ref, 'refs/tags/') == false) && (startsWith(inputs.tag_name, 'v') == false)
         shell: pwsh
         env:
           SIGN_PHRASE: ${{ secrets.SELFSIGN_PHRASE }}
@@ -231,7 +231,7 @@ jobs:
 
   sign_binaries_for_EK_USB_image:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/') || inputs.is_at_tag
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tag_name, 'v')
     runs-on: windows-latest
 
     steps:
@@ -287,11 +287,12 @@ jobs:
         if: steps.sign_binaries.outcome == 'success'
         with:
           files: kolibri-windows.zip
+          tag_name: inputs.tag_name
 
 
   push_to_MS_store:
     needs: package
-    if: startsWith(github.ref, 'refs/tags/') || inputs.is_at_tag
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tag_name, 'v')
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -48,5 +48,5 @@ jobs:
     if: needs.tag.outputs.tag_string
     uses: ./.github/workflows/main.yml
     with:
-      is_at_tag: true
+      tag_name: ${{ needs.tag.outputs.tag_string }}
     secrets: inherit


### PR DESCRIPTION
The release step with softprops/action-gh-release@v1 [1] uploading the
artifact to the release page needs the tag_name. The tag_name defaults
to github.ref.

However, the github.ref is not at a tag when the tag.yml is triggered on
master branch, even CI has created a tag. For example, the schedule
event. This leads softprops/action-gh-release@v1 fails to upload the
artifact.

This commit fixes the issue by passing the tag's name as the inputs of
softprops/action-gh-release@v1.

[1] https://github.com/softprops/action-gh-release

https://phabricator.endlessm.com/T33610