### PR TITLE
CI: Drop 32 bits build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        architecture: [x86, x64]
+        architecture: [x64]
 
     steps:
       - name: Checkout
@@ -190,7 +190,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        architecture: [x86, x64]
+        architecture: [x64]
 
     steps:
       - name: Checkout
@@ -255,7 +255,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        architecture: [x86, x64]
+        architecture: [x64]
 
     steps:
       - name: Download the kolibri-windows.zip


### PR DESCRIPTION
Drop 32 bits build from matrix. We can get it back if it is needed in
the future.

https://phabricator.endlessm.com/T33648