### PR TITLE
electron: Set KOLIBRI_PROJECT env by detecting app's directory

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -90,7 +90,17 @@ async function loadKolibriEnv(useKey) {
   env.KOLIBRI_HOME = KOLIBRI_HOME;
   env.PYTHONPATH = KOLIBRI_EXTENSIONS;
   env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
-  env.KOLIBRI_PROJECT = METRICS_ID
+
+  const APPXMSIX_PATTERN = 'Program Files\\WindowsApps'
+  if (__dirname.includes(APPXMSIX_PATTERN)) {
+    console.log('loading kolibri env, using as Windows APPX/MSIX application');
+    env.KOLIBRI_PROJECT = METRICS_ID
+  }
+
+  if (!env.KOLIBRI_PROJECT) {
+    console.log('loading kolibri env, using as Windows standalone application');
+    env.KOLIBRI_PROJECT = `${METRICS_ID}-standalone`
+  }
 
   if (!useKey) {
     setupProvision();


### PR DESCRIPTION
Endless Key (Windows) is only delivered as two types: APPX/MSIX from
Microsoft store, or the zip/image format which might be in an USB key
currently.

We would like to know it runs in which environment. So, only set the
KOLIBRI_PROJECT env as 'endless-key-windows' as the metrics ID when it's
directory name includes APPX/MSIX pattern.

https://phabricator.endlessm.com/T33665