### PR TITLE
electron: Improve the way to detect it is an APPX, or not

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -92,7 +92,7 @@ async function loadKolibriEnv(useKey) {
   env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
   env.KOLIBRI_CONTENT_COLLECTIONS_PATH = path.join(__dirname, "collections");
 
-  const APPXMSIX_PATTERN = 'Program Files\\WindowsApps'
+  const APPXMSIX_PATTERN = path.join(env.PROGRAMFILES, "WindowsApps");
   if (__dirname.includes(APPXMSIX_PATTERN)) {
     console.log('loading kolibri env, using as Windows APPX/MSIX application');
     env.KOLIBRI_PROJECT = METRICS_ID;


### PR DESCRIPTION
We set the Endless Key (Windows)'s metrics ID by detecting the directory
path. However, the original pattern "Program Files\\WindowsApps"'s
"Program Files" might be other string with different localization. For
example, "Program Files" in French will be "Programmes". This will
confuse the metrics. Even, the app is installed from an APPX package or
Microsoft store.

This patch replaces the "Program Files" with the environment variable
%PROGRAMFILES% on Windows, which already takes care the localization.

https://phabricator.endlessm.com/T33688