### PR TITLE
electron: Add the appId for APPX/MSIX packaging

### DIFF
--- a/kolibri-electron/package.json
+++ b/kolibri-electron/package.json
@@ -58,5 +58,8 @@
     "@electron-forge/maker-squirrel": "^6.0.0-beta.64",
     "@electron-forge/maker-zip": "^6.0.0-beta.64",
     "electron": "19.0.6"
+  },
+  "build": {
+    "appId": "EndlessOSFoundation.EndlessKey"
   }
 }


### PR DESCRIPTION
Add the appId into kolibri_electron's packaging for APPX/MSIX package.

https://phabricator.endlessm.com/T33819