### PR TITLE
Pin kolibri-explore-plugin to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Add kolibri_explore_plugin to Kolibri's dist packages
         run: |
-          pip install kolibri-explore-plugin --target="src\kolibri\dist"
+          pip install "kolibri-explore-plugin>=2,<3" --target="src\kolibri\dist"
 
       - uses: robinraju/release-downloader@v1.3
         with:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ launch the Kolibri server with a minimal configuration.
 ```
     pip install kolibri --target="dist\Kolibri\"
     pip install kolibri-zim-plugin --target="dist\kolibri\kolibri\dist"
-    pip install kolibri-explore-plugin --target="dist\kolibri\kolibri\dist"
+    pip install "kolibri-explore-plugin>=2,<3" --target="dist\kolibri\kolibri\dist"
 ```
 
  * Download app-bundle and unzip it in apps-bundle:


### PR DESCRIPTION
Because v3 will be targetting Kolibri 0.16

https://phabricator.endlessm.com/T33846