### PR TITLE
Attempt to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           architecture: ${{ matrix.architecture }}
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'yarn'
@@ -41,7 +41,7 @@ jobs:
           pip install wheel
 
       - name: Checkout pyinstaller
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: pyinstaller/pyinstaller
           path: pyinstaller
@@ -192,7 +192,7 @@ jobs:
         shell: pwsh
 
       - name: Upload ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "kolibri-windows_${{ matrix.architecture }}.zip"
           path: "kolibri-windows_${{ matrix.architecture }}.zip"
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Need to fetch everything so that 'git describe' can see the tags
           fetch-depth: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,11 +230,13 @@ jobs:
       - name: Using version from inputs
         if: startsWith(inputs.tag_name, 'v')
         run: |
-          $ver_arr =  "${{ github.event.inputs.tag_name }}" -split '[-v]'
+          $ver_arr =  "$env:TAG_NAME" -split '[-v]'
           # Always ".0" to make it windows store compatible
           $ver_str = $ver_arr[1] + ".0"
           echo "BUILD_VERSION=$ver_str" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
         shell: pwsh
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
 
       - name: Using version from ref
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Need to fetch everything so that 'git describe' can see the tags
           fetch-depth: 0
@@ -37,6 +37,7 @@ jobs:
 
       - name: Create a new tag
         if: steps.have_new_tag_string.outputs.tag_string
+        # TODO: https://github.com/negz/create-tag/issues/14
         uses: negz/create-tag@v1
         with:
           version: ${{ steps.have_new_tag_string.outputs.tag_string }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Have a new tag string
         id: have_new_tag_string
+        shell: pwsh
         run: |
           $describe = (git describe --always --tags --long --match 'v*')
           $ver_arr = $describe -split '[-v\.]'
@@ -33,7 +34,7 @@ jobs:
           } else {
             $tag_str = ""
           }
-          echo "::set-output name=tag_string::$tag_str"
+          echo "tag_string=$tag_str" >> $Env:GITHUB_OUTPUT
 
       - name: Create a new tag
         if: steps.have_new_tag_string.outputs.tag_string


### PR DESCRIPTION
The weekly tag workflow was disabled because the repo was inactive for 60 days. (There appears to be no [non-hacky](https://stackoverflow.com/questions/67184368/prevent-scheduled-github-actions-from-becoming-disabled) way to prevent this. I guess it's fair enough but it is useful to know.)

When I reënabled it, the `build_for_tag / package (x64)` step failed:

```
Set package's version as .0

...

MakeAppx : error: Error info: error C00CE169: App manifest validation error: The app manifest must be valid as per schema: Line 9, Column 5, Reason: '.0' violates pattern constraint of '(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\.(0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])){3}'.
```

I think bfa3ff088e67f4dcbe56ca30305f7676ba746371 must be not quite right.  The log output in the failed job run shows that the `tag_string` input is set correctly (or else this step would not be run) but `github.event.inputs.tag_name` is evidently empty.
    
Following the documentation at https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs, let's try passing `inputs.tag_string` to the script via an environment variable, then referencing that.

While we're here I fixed some use of deprecated GitHub Actions API.
    
https://phabricator.endlessm.com/T34654


