### PR TITLE
ci: Change Kolibri wheel URL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Prep kolibri dist
         env:
-          KOLIBRI_WHL_URL: 'https://buildkite.com/organizations/learningequality/pipelines/kolibri-python-package/builds/6389/jobs/018385cc-d517-4f48-b281-193b9933d562/artifacts/018385d4-10d6-443b-868e-319b7c4eb2de'
+          KOLIBRI_WHL_URL: 'https://github.com/endlessm/kolibri-explore-plugin/releases/download/v5.8.0/kolibri-0.16.0.dev0+git.20220928203123-py2.py3-none-any.whl'
           KOLIBRI_WHL_FILENAME: "kolibri-0.16.0.dev0+git.20220928203123-py2.py3-none-any.whl"
         run: |
           C:\msys64\usr\bin\wget.exe -O $env:KOLIBRI_WHL_FILENAME $env:KOLIBRI_WHL_URL


### PR DESCRIPTION
The wheel file was removed from buildkite.com, so we uploaded it to our kolibri-explore-release github release.

https://github.com/endlessm/kolibri-installer-android/pull/115/commits/e4a7709cce54260381c44e8f252564a05994e2c2