### PR TITLE
ci: Keep the py files to avoid old djago's database migration issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,8 +110,8 @@ jobs:
         run: |
           # Precompile the py as pyc files
           python.exe -m compileall src\kolibri\ -b
-          # Remove py source files
-          Get-Childitem -Path src\kolibri\ -Include *.py -File -Recurse | Remove-Item -Force
+          # Remove py source files, except the DB migrations https://github.com/endlessm/endless-key-app/pull/99
+          Get-Childitem -Path src\kolibri\ -Include *.py -File -Recurse | where-object fullname -notlike "*\migrations\*.py" | Remove-Item -Force
           # Build as a Windows executable binary
           pyinstaller.exe --noconfirm main.spec
           # Remove the __pycache__


### PR DESCRIPTION
Current Kolibri uses old django 1.11.29, which does not support migrations feature from loaded .pyc files [1]. That blocks new data models generating/updating tables in the database.

So, keep the original and do not precompile the original py files.

After Django is update to 2.1, we can reconsider this approach.

[1]: https://code.djangoproject.com/ticket/23406

https://phabricator.endlessm.com/T34660