### PR TITLE
ci: Generate appcert report for APPX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,6 +290,34 @@ jobs:
           path: "endlesskey_${{ matrix.architecture }}.selfsigned.appx"
 
 
+  check_with_appcert:
+    needs: package
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        architecture: [x64]
+
+    steps:
+      - name: Download the APPX package
+        uses: actions/download-artifact@v3
+        with:
+          name: endlesskey_${{ matrix.architecture }}.appx
+
+      - name: Check with AppCert locally
+        run: |
+          $LOCALPATH = Get-Location
+          $APPX_FULLPATH = "$LOCALPATH\endlesskey_${{ matrix.architecture }}.appx"
+          $REPORT_FULLPATH = "$LOCALPATH\endlesskey_${{ matrix.architecture }}_certreport.xml"
+          & "${Env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\appcert.exe" reset
+          & "${Env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\appcert.exe" test -appxpackagepath ${APPX_FULLPATH} -reportoutputpath ${REPORT_FULLPATH}
+
+      - name: Upload AppCert report
+        uses: actions/upload-artifact@v3
+        with:
+          name: "endlesskey_${{ matrix.architecture }}_certreport.xml"
+          path: "endlesskey_${{ matrix.architecture }}_certreport.xml"
+
+
   sign_binaries_for_EK_USB_image:
     needs: build
     if: startsWith(github.ref, 'refs/tags/') || startsWith(inputs.tag_name, 'v')


### PR DESCRIPTION
Generate report for APPX package with Windows App Certification Kit locally.

Note: This is only for local test. The real certification is on Microsoft store and might be different.

https://phabricator.endlessm.com/T34622