### PR TITLE
APPX: Bump TargetDeviceFamily's MinVersion to 10.0.17763.0

### DIFF
--- a/build_winapp/appxmanifest.xml
+++ b/build_winapp/appxmanifest.xml
@@ -21,7 +21,7 @@
   <Dependencies>
     <TargetDeviceFamily
       Name="Windows.Desktop"
-      MinVersion="10.0.14316.0"
+      MinVersion="10.0.17763.0"
       MaxVersionTested="10.0.19041.0" />
   </Dependencies>
   <Capabilities>


### PR DESCRIPTION
Sync the TargetDeviceFamily's MinVersion with the appxmanifest.xml generated from Visual Studio 2022.

https://phabricator.endlessm.com/T34622