### PR TITLE
electron: Pass the selected package from WelcomeWrapper to electron process

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -85,7 +85,7 @@ function setupProvision() {
   env.KOLIBRI_AUTOMATIC_PROVISION_FILE = provision_file;
 }
 
-async function loadKolibriEnv(useKey) {
+async function loadKolibriEnv(useKey, packId) {
   console.log(`loading kolibri env, using USB: ${useKey}`);
   env.KOLIBRI_HOME = KOLIBRI_HOME;
   env.PYTHONPATH = KOLIBRI_EXTENSIONS;
@@ -104,6 +104,11 @@ async function loadKolibriEnv(useKey) {
   }
 
   if (!useKey) {
+    if (packId != "") {
+      console.log(`loading kolibri env, using package: ${packId}`);
+      env.KOLIBRI_INITIAL_CONTENT_PACK = packId;
+    }
+
     setupProvision();
     return false;
   }
@@ -250,7 +255,7 @@ async function createWindow() {
     mainWindow.webContents.executeJavaScript('WelcomeApp.showConnectKeyRequired()', true);
   } else {
     DETECT_USB_CHANGES = false;
-    loadKolibriEnv(fs.existsSync(USB_CONTENT_FLAG_FILE)).then(() => {
+    loadKolibriEnv(fs.existsSync(USB_CONTENT_FLAG_FILE), '').then(() => {
       runKolibri();
     });
   }
@@ -312,7 +317,10 @@ app.on('ready', () => {
 
   ipcMain.on('load', (_event, data) => {
     DETECT_USB_CHANGES = false;
-    loadKolibriEnv(data.usb).then(() => {
+    if (!('pack' in data)) {
+      data['pack'] = '';
+    }
+    loadKolibriEnv(data.usb, data.pack).then(() => {
       runKolibri();
     });
   });

--- a/kolibri-electron/src/preload.js
+++ b/kolibri-electron/src/preload.js
@@ -1,9 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('WelcomeWrapper', {
-    // Triggers the Kolibri load, configured to not use the USB
+    // Triggers the Kolibri load, configured to not use the USB and specified package
     startWithNetwork: (packId) => {
-        ipcRenderer.send('load', { usb: false });
+        ipcRenderer.send('load', { usb: false, pack: packId });
     },
     // Triggers the Kolibri load, configured to use the USB content
     startWithUSB: () => {


### PR DESCRIPTION
Here is already the function to get the selected package ID from WelcomeWrapper within the contextBridge mechanism which exposes "load" data to the electron main process.

However, it only passes using Kolibri data in the USB storage, or not originally. This patch passes the selected package ID, too. So, electron can tell Kolibri use the correct package by setting the environment variable KOLIBRI_INITIAL_CONTENT_PACK, instead of always the default explorer.

After downloaded the package and restart kolibri-electron.exe, simply passes an empty string as the packId argument of loadKolibriEnv function. It will use what it has in the filesystem which is the content in the USB storage, or the downloaded package.

https://phabricator.endlessm.com/T34742