### PR TITLE
Github action: Pin Explore plugin to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Add kolibri_explore_plugin to Kolibri's dist packages
         run: |
-          pip install kolibri-explore-plugin --target="src\kolibri\dist"
+          pip install kolibri-explore-plugin~=5.0 --target="src\kolibri\dist"
 
       - uses: robinraju/release-downloader@v1.7
         with:


### PR DESCRIPTION
The version compatible with current Kolibri wheel.

https://phabricator.endlessm.com/T34559