### PR TITLE
electron: Set env KOLIBRI_USE_EK_IGUANA_PAGE when no init content pack is passed

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -113,6 +113,11 @@ async function loadKolibriEnv(useKey, packId) {
     return false;
   }
 
+  if (packId == "") {
+    console.log('loading kolibri env, using EK IGUANA PAGE');
+    env.KOLIBRI_USE_EK_IGUANA_PAGE = "1";
+  }
+
   const keyData = await getEndlessKeyDataPath();
   if (!keyData) {
     setupProvision();


### PR DESCRIPTION
When use the content from Endless USB key, the Discovery page shows blank. Because  So, set the enviroment variable
KOLIBRI_USE_EK_IGUANA_PAGE with "1" when no initial content pack is passed to Kolibri.

https://phabricator.endlessm.com/T34756