### PR TITLE
CI: Lift Kolibri's path to Endless Key app's root path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,7 +183,7 @@ jobs:
           mv $ElectronDiretory kolibri-windows
 
           mv src/kolibri dist/Kolibri/kolibri
-          mv dist/Kolibri kolibri-windows/resources/app/src/
+          mv dist/Kolibri kolibri-windows/
           mv src/apps-bundle kolibri-windows/resources/app/src/
           mv src/collections kolibri-windows/resources/app/src/
 

--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -25,7 +25,8 @@ let maxRetries = 3;
 let django = null;
 
 let KOLIBRI_HOME_TEMPLATE = '';
-let KOLIBRI_EXTENSIONS = path.join(__dirname, 'Kolibri', 'kolibri', 'dist');
+let KOLIBRI_APPDIR = path.normalize(path.join(__dirname, '..', '..', '..', 'Kolibri'));
+let KOLIBRI_EXTENSIONS = path.join(KOLIBRI_APPDIR, 'kolibri', 'dist');
 let KOLIBRI_HOME = path.join(userData, 'endless-key');
 const METRICS_ID = 'endless-key-windows';
 const AUTOPROVISION_FILE = path.join(__dirname, 'automatic_provision.json');
@@ -142,7 +143,7 @@ async function loadKolibriEnv(useKey, packId) {
 }
 
 async function getLoadingScreen() {
-  const defaultLoading = path.join(__dirname, 'Kolibri', 'assets', '_load.html');
+  const defaultLoading = path.join(KOLIBRI_APPDIR, 'assets', '_load.html');
 
   const welcome = path.join(
     KOLIBRI_EXTENSIONS,
@@ -293,7 +294,7 @@ const runKolibri = () => {
 
   removePidFile();
 
-  django = child_process.spawn(path.join(__dirname, 'Kolibri', 'Kolibri.exe'));
+  django = child_process.spawn(path.join(KOLIBRI_APPDIR, 'Kolibri.exe'));
   django.stdout.on('data', (data) => {
     console.log(`Kolibri: ${data}`);
   });


### PR DESCRIPTION
Endless Key app is composed with an Electron app as the frontend and Kolibri as the backend. Kolibri is installed under the Electron app's src path originally: resources/app/src.

However, Endless Key app's Windows App Cert Kit cannot scan the file whose full path name exceeds length 259. Otherwise, the scan breaks due to exceptions.

So, move Kolibri to Endless Key app's root path. Hope this action ease the length limitation.

https://phabricator.endlessm.com/T34780