### PR TITLE
CI: Fix kolibri.exe's path going to be signed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -359,14 +359,14 @@ jobs:
             -ProjectSlug Endless_Apps `
             -SigningPolicySlug Endless_Apps_Signing_for_Endless_USB_Key `
             -ArtifactConfigurationSlug Binaries_for_Endless_USB_Key `
-            -InputArtifactPath kolibri-windows/resources/app/src/Kolibri/Kolibri.exe `
+            -InputArtifactPath kolibri-windows/Kolibri/Kolibri.exe `
             -OutputArtifactPath Kolibri.signed.exe `
             -WaitForCompletion
 
           rm kolibri-windows/kolibri-electron.exe
-          rm kolibri-windows/resources/app/src/Kolibri/Kolibri.exe
+          rm kolibri-windows/Kolibri/Kolibri.exe
           mv kolibri-electron.signed.exe kolibri-windows/kolibri-electron.exe
-          mv Kolibri.signed.exe kolibri-windows/resources/app/src/Kolibri/Kolibri.exe
+          mv Kolibri.signed.exe kolibri-windows/Kolibri/Kolibri.exe
 
           rm kolibri-windows_${{ matrix.architecture }}.zip
 


### PR DESCRIPTION
The commit d244fd3 ("CI: Lift Kolibri's path to Endless Key app's root path") moves:
original path kolibri-windows/resources/app/src/Kolibri/Kolibri.exe to kolibri-windows/Kolibri/Kolibri.exe.

However, sign_binaries_for_EK_USB_image job fails, because the path has not been updated. This commit fixes it.

Fixes: https://github.com/endlessm/endless-key-app/issues/112