### PR TITLE
CI: Add bumpversion.yml workflow as a webhook target

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -33,4 +33,6 @@ jobs:
   create_tag:
     needs: bump-version
     uses: ./.github/workflows/tag.yml
+    with:
+      kep_version: ${{ github.event.client_payload.VERSION }}
     secrets: inherit

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -1,0 +1,36 @@
+name: Bump_Version
+
+on:
+  repository_dispatch:
+    types: [kolibri-explore-plugin-release]
+
+jobs:
+  bump-version:
+    runs-on: windows-latest
+
+    steps:
+      - name: Set up Git environment
+        run: |
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email ${{ github.actor }}@github.com
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # When there are multiple matched tags at the same commit, "git describe"
+      # only gets the first matched tag, not the latest one. That leads generate
+      # conflicted tag next time, due to the same tag name. So, append a dummy
+      # commit here.
+      - name: Append a new commit for new kolibri-explore-plugin release
+        if: ${{ github.event.action == 'kolibri-explore-plugin-release' }}
+        shell: pwsh
+        run: |
+          git commit --allow-empty -m "Bump kolibri-explore-plugin version to $VERSION"
+        env:
+          VERSION: ${{ github.event.client_payload.VERSION }}
+
+
+  create_tag:
+    needs: bump-version
+    uses: ./.github/workflows/tag.yml
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,20 @@ jobs:
     strategy:
       matrix:
         architecture: [x64]
+    env:
+      branch: ${{ github.ref }}
 
     steps:
+      - name: Set branch if this is triggered by workflow_call
+        if: startsWith(inputs.tag_name, 'v')
+        run: |
+          # The github.ref is not at the tag, if it is triggered by workflow_call
+          $env:branch = ${{ inputs.tag_name }}
+
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ env.branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -204,11 +214,20 @@ jobs:
     strategy:
       matrix:
         architecture: [x64]
+    env:
+      branch: ${{ github.ref }}
 
     steps:
+      - name: Set branch if this is triggered by workflow_call
+        if: startsWith(inputs.tag_name, 'v')
+        run: |
+          # The github.ref is not at the tag, if it is triggered by workflow_call
+          $env:branch = ${{ inputs.tag_name }}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ env.branch }}
           # Need to fetch everything so that 'git describe' can see the tags
           fetch-depth: 0
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,6 +13,12 @@ jobs:
       tag_string: ${{ steps.have_new_tag_string.outputs.tag_string }}
 
     steps:
+      - name: Set up Git environment
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email ${{ github.actor }}@github.com
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -39,12 +45,12 @@ jobs:
 
       - name: Create a new tag
         if: steps.have_new_tag_string.outputs.tag_string
-        # TODO: https://github.com/negz/create-tag/issues/14
-        uses: negz/create-tag@v1
-        with:
+        run: |
+          git tag -a $version -m $message
+          git push origin $version
+        env:
           version: ${{ steps.have_new_tag_string.outputs.tag_string }}
           message: "Release ${{ steps.have_new_tag_string.outputs.tag_string }}"
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   build_for_tag:
     needs: tag

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,6 +3,7 @@ name: Tag Weekly
 on:
   schedule:
     - cron: '32 18 * * SAT'
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '32 18 * * SAT'
   workflow_call:
+    inputs:
+      kep_version:
+        description: 'The version of kolibri-explore-plugin'
+        default: ''
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -29,19 +34,40 @@ jobs:
         id: have_new_tag_string
         shell: pwsh
         run: |
+          $kep_updated = 0
+
+          # Split endless-key-app's tag into fields
           $describe = (git describe --always --tags --long --match 'v*')
           $ver_arr = $describe -split '[-v\.]'
           $major = $ver_arr[1]
           $minor = $ver_arr[2]
           $build = $ver_arr[3] -as [int]
           $revision = $ver_arr[4]
+
+          if ($kep_version -ne '') {
+            # Split kolibri-explore-plugin's version into fields
+            $kep_ver_arr = $kep_version -split '[-v\.]'
+            $kep_major = $kep_ver_arr[1]
+            $kep_minor = $kep_ver_arr[2]
+
+            if ($kep_major -ne $major -or $kep_minor -ne $minor)
+            {
+              $major = $kep_major
+              $minor = $kep_minor
+              $build = 0
+              $kep_updated = 1
+            }
+          }
+
           # Do not create a new tag if latest tag is at HEAD
-          if ($revision -ne 0) {
+          if ($kep_updated -or $revision -ne 0) {
             $tag_str = "v" + $major + "." + $minor + "." + ($build + 1)
           } else {
             $tag_str = ""
           }
           echo "tag_string=$tag_str" >> $Env:GITHUB_OUTPUT
+        env:
+          kep_version: ${{ inputs.kep_version }}
 
       - name: Create a new tag
         if: steps.have_new_tag_string.outputs.tag_string

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   tag:
     runs-on: windows-latest
+    env:
+      branch: ${{ github.ref }}
     outputs:
       tag_string: ${{ steps.have_new_tag_string.outputs.tag_string }}
 
@@ -24,9 +26,17 @@ jobs:
           git config --global user.name ${{ github.actor }}
           git config --global user.email ${{ github.actor }}@github.com
 
+      - name: Set branch if this is triggered by kolibri-explore-plugin release flow
+        if: ${{ inputs.kep_version != '' }}
+        run: |
+          # The kolibri-explore-plugin release flow will append a new commit to master branch.
+          # Therefor, the github.ref is not at the latest commit. Checkout master instead.
+          $env:branch = "master"
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ env.branch }}
           # Need to fetch everything so that 'git describe' can see the tags
           fetch-depth: 0
 


### PR DESCRIPTION
Add bumpversion.yml workflow as a webhook target/entry to bump release version. It accepts a new kolibri-explore-plugin release's trigger now. When it gets a new kolibri-explore-plugin release, it will append a dummy commit, then invoke the tag.yml workflow to create a new tag.

https://phabricator.endlessm.com/T34806