### PR TITLE
CI: Fix the usage of environment and input variables

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -25,7 +25,7 @@ jobs:
         if: ${{ github.event.action == 'kolibri-explore-plugin-release' }}
         shell: pwsh
         run: |
-          git commit --allow-empty -m "Bump kolibri-explore-plugin version to $VERSION"
+          git commit --allow-empty -m "Bump kolibri-explore-plugin version to $env:VERSION"
         env:
           VERSION: ${{ github.event.client_payload.VERSION }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         if: startsWith(inputs.tag_name, 'v')
         run: |
           # The github.ref is not at the tag, if it is triggered by workflow_call
-          $env:branch = ${{ inputs.tag_name }}
+          $env:branch = '${{ inputs.tag_name }}'
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -225,7 +225,7 @@ jobs:
         if: startsWith(inputs.tag_name, 'v')
         run: |
           # The github.ref is not at the tag, if it is triggered by workflow_call
-          $env:branch = ${{ inputs.tag_name }}
+          $env:branch = '${{ inputs.tag_name }}'
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Create a new tag
         if: steps.have_new_tag_string.outputs.tag_string
         run: |
-          git tag -a $version -m $message
-          git push origin $version
+          git tag -a $env:version -m $env:message
+          git push origin $env:version
         env:
           version: ${{ steps.have_new_tag_string.outputs.tag_string }}
           message: "Release ${{ steps.have_new_tag_string.outputs.tag_string }}"


### PR DESCRIPTION
Fixes commit ("CI: Use git to create & push a new tag directly") and
("CI: Fix actions/checkout's ref for bumping version").

https://phabricator.endlessm.com/T34806