### PR TITLE
CI: Fix the way to set environment variable branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         if: startsWith(inputs.tag_name, 'v')
         run: |
           # The github.ref is not at the tag, if it is triggered by workflow_call
-          $env:branch = '${{ inputs.tag_name }}'
+          echo "branch=${{ inputs.tag_name }}" >> $env:GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -225,7 +225,7 @@ jobs:
         if: startsWith(inputs.tag_name, 'v')
         run: |
           # The github.ref is not at the tag, if it is triggered by workflow_call
-          $env:branch = '${{ inputs.tag_name }}'
+          echo "branch=${{ inputs.tag_name }}" >> $env:GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # The kolibri-explore-plugin release flow will append a new commit to master branch.
           # Therefor, the github.ref is not at the latest commit. Checkout master instead.
-          $env:branch = "master"
+          echo "branch=master" >> $env:GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The original way to set $env:branch does not effect on other steps of GitHub actions. Notice appending a line of environment variable with value to $env:GITHUB_ENV is the correct method. [1]

[1]: https://www.jamescroft.co.uk/setting-github-actions-environment-variables-in-powershell/

https://phabricator.endlessm.com/T34806