### PR TITLE
Fix git tagging

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: windows-latest
     env:
       branch: ${{ github.ref }}
+      branch_to_push: ${{ github.ref_name }}
     outputs:
       tag_string: ${{ steps.have_new_tag_string.outputs.tag_string }}
 
@@ -26,6 +27,7 @@ jobs:
           # The kolibri-explore-plugin release flow will append a new commit to master branch.
           # Therefor, the github.ref is not at the latest commit. Checkout master instead.
           echo "branch=master" >> $env:GITHUB_ENV
+          echo "branch_to_push=master" >> $env:GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,7 +85,7 @@ jobs:
         if: steps.have_new_tag_string.outputs.tag_string
         run: |
           git tag -a $env:version -m $env:message
-          git push origin $env:version
+          git push origin $env:version $env:branch_to_push
         env:
           version: ${{ steps.have_new_tag_string.outputs.tag_string }}
           message: "Release ${{ steps.have_new_tag_string.outputs.tag_string }}"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,12 +20,6 @@ jobs:
       tag_string: ${{ steps.have_new_tag_string.outputs.tag_string }}
 
     steps:
-      - name: Set up Git environment
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          git config --global user.name ${{ github.actor }}
-          git config --global user.email ${{ github.actor }}@github.com
-
       - name: Set branch if this is triggered by kolibri-explore-plugin release flow
         if: ${{ inputs.kep_version != '' }}
         run: |
@@ -78,6 +72,12 @@ jobs:
           echo "tag_string=$tag_str" >> $Env:GITHUB_OUTPUT
         env:
           kep_version: ${{ inputs.kep_version }}
+
+      - name: Set up Git environment
+        if: steps.have_new_tag_string.outputs.tag_string
+        run: |
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email ${{ github.actor }}@github.com
 
       - name: Create a new tag
         if: steps.have_new_tag_string.outputs.tag_string


### PR DESCRIPTION
A couple fixes needed when a new commit and tag are made when triggered by a kolibri-explore-plugin release.