### PR TITLE
kolibri-electron: Bump electron to v22.3.16

### DIFF
--- a/kolibri-electron/package.json
+++ b/kolibri-electron/package.json
@@ -57,7 +57,7 @@
     "@electron-forge/maker-rpm": "^6.0.0",
     "@electron-forge/maker-squirrel": "^6.0.0",
     "@electron-forge/maker-zip": "^6.0.0",
-    "electron": "22.3.7"
+    "electron": "^22.3.18"
   },
   "build": {
     "appId": "EndlessOSFoundation.EndlessKey"

--- a/kolibri-electron/yarn.lock
+++ b/kolibri-electron/yarn.lock
@@ -990,10 +990,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron@22.3.7:
-  version "22.3.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.7.tgz#1df3d15f8cee6468818485596b0d88840fa34018"
-  integrity sha512-QUuRCl0QJk0w2yPAQXl6sk4YV1b9353w4e1eO/fF2OUmrGQV9Fy2pEpEDV1PIq/JJ/oeVVlI3H07LHpEcNb0TA==
+electron@^22.3.18:
+  version "22.3.18"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.18.tgz#5ee55633b3912fec9df6d8f039acf2c016274cfc"
+  integrity sha512-JgjB966ghTBszAX/GgVgDY/2CktWCjTZWGJI0WISRHDudBZ8/WPkI/hIjsMiLQLe0wSTk6S+WHOYbIqyw0I/sg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
Electron Release stable version includes 22.3.16 with node.js 16. https://releases.electronjs.org/release/v22.3.16

Hope this fix the PDF reader rendering with an NVIDIA card issue.

Fixes: https://github.com/endlessm/endless-key-app/issues/133