### PR TITLE
CI: Bump Kolibri to v0.16.0-beta0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,8 +76,8 @@ jobs:
 
       - name: Prep kolibri dist
         env:
-          KOLIBRI_WHL_URL: 'https://github.com/learningequality/kolibri/releases/download/v0.16.0-alpha18/kolibri-0.16.0a18-py2.py3-none-any.whl'
-          KOLIBRI_WHL_FILENAME: "kolibri-0.16.0a18-py2.py3-none-any.whl"
+          KOLIBRI_WHL_URL: 'https://github.com/learningequality/kolibri/releases/download/v0.16.0-beta0/kolibri-0.16.0b0-py2.py3-none-any.whl'
+          KOLIBRI_WHL_FILENAME: "kolibri-0.16.0b0-py2.py3-none-any.whl"
         run: |
           C:\msys64\usr\bin\wget.exe -O $env:KOLIBRI_WHL_FILENAME $env:KOLIBRI_WHL_URL
           pip install $env:KOLIBRI_WHL_FILENAME --target="src"


### PR DESCRIPTION
Since kolibri-explore-plugin's PR [Use Kolibri's FileDownloader](https://github.com/endlessm/kolibri-explore-plugin/pull/729) has been merged, the app side can bump Kolibri to v0.16.0-beta0.