### PR TITLE
electron: Drop USB APIs relating to Welcome screen

### DIFF
--- a/kolibri-electron/src/index.js
+++ b/kolibri-electron/src/index.js
@@ -31,43 +31,10 @@ let KOLIBRI_HOME = path.join(userData, 'endless-key');
 const METRICS_ID = 'endless-key-windows';
 const AUTOPROVISION_FILE = path.join(__dirname, 'automatic_provision.json');
 
-const LOCK_FILE = {
-  handler: null,
-  path: null,
-};
-
-const USB_CONTENT_FLAG_FILE = path.join(KOLIBRI_HOME, 'usb_content_flag');
-
 function removePidFile() {
   const pidFile = path.join(KOLIBRI_HOME, 'server.pid');
   if (fs.existsSync(pidFile)) {
     fs.rmSync(pidFile);
-  }
-}
-
-async function getEndlessKeyDataPath() {
-  const drives = await drivelist.list();
-
-  const accessPromises = drives.map(async (drive) => {
-
-    const mountpoint = drive.mountpoints[0];
-
-    if (!mountpoint) {
-      throw Error("Drive is not mounted");
-    }
-
-    const keyData = path.join(mountpoint.path, 'KOLIBRI_DATA');
-
-    // thows an Error on fail
-    await fsPromises.access(keyData);
-    return keyData;
-  });
-
-  try {
-    const keyData = await Promise.any(accessPromises);
-    return keyData;
-  } catch (error) {
-    return undefined;
   }
 }
 
@@ -84,61 +51,23 @@ function setupProvision() {
   env.KOLIBRI_AUTOMATIC_PROVISION_FILE = provision_file;
 }
 
-async function loadKolibriEnv(useKey, packId) {
-  console.log(`loading kolibri env, using USB: ${useKey}`);
+async function loadKolibriEnv(packId) {
   env.KOLIBRI_HOME = KOLIBRI_HOME;
   env.DJANGO_SETTINGS_MODULE = "kolibri_tools.endless_key_settings";
   env.PYTHONPATH = KOLIBRI_EXTENSIONS;
   env.KOLIBRI_APPS_BUNDLE_PATH = path.join(__dirname, "apps-bundle", "apps");
   env.KOLIBRI_CONTENT_COLLECTIONS_PATH = path.join(__dirname, "collections");
 
-  const APPXMSIX_PATTERN = path.join(env.PROGRAMFILES, "WindowsApps");
-  if (__dirname.includes(APPXMSIX_PATTERN)) {
-    console.log('loading kolibri env, using as Windows APPX/MSIX application');
-    env.KOLIBRI_PROJECT = METRICS_ID;
+  console.log('loading kolibri env, using as Windows APPX/MSIX application');
+  env.KOLIBRI_PROJECT = METRICS_ID;
+
+  if (packId != "") {
+    console.log(`loading kolibri env, using package: ${packId}`);
+    env.KOLIBRI_INITIAL_CONTENT_PACK = packId;
   }
 
-  if (!env.KOLIBRI_PROJECT) {
-    console.log('loading kolibri env, using as Windows standalone application');
-    env.KOLIBRI_PROJECT = `${METRICS_ID}-standalone`;
-  }
-
-  if (!useKey) {
-    if (packId != "") {
-      console.log(`loading kolibri env, using package: ${packId}`);
-      env.KOLIBRI_INITIAL_CONTENT_PACK = packId;
-    }
-
-    setupProvision();
-    return false;
-  }
-
-  if (packId == "") {
-    console.log('loading kolibri env, using EK IGUANA PAGE');
-    env.KOLIBRI_USE_EK_IGUANA_PAGE = "1";
-  }
-
-  const keyData = await getEndlessKeyDataPath();
-  if (!keyData) {
-    setupProvision();
-    return false;
-  }
-
-  KOLIBRI_HOME_TEMPLATE = path.join(keyData, 'preseeded_kolibri_home');
-  env.KOLIBRI_CONTENT_FALLBACK_DIRS = path.join(keyData, 'content');
-
-  if (!fs.existsSync(KOLIBRI_HOME) && fs.existsSync(KOLIBRI_HOME_TEMPLATE)) {
-    await fsExtra.copy(KOLIBRI_HOME_TEMPLATE, KOLIBRI_HOME);
-    // Just create the flag file in the KOLIBRI_HOME
-    handler = await fsPromises.open(USB_CONTENT_FLAG_FILE, 'w');
-    handler.close();
-  }
-
-  // Lock USB
-  LOCK_FILE.path = path.join(keyData, 'lock');
-  LOCK_FILE.handler = await fsPromises.open(LOCK_FILE.path, 'w');
-
-  return true;
+  setupProvision();
+  return;
 }
 
 async function getLoadingScreen() {
@@ -232,7 +161,7 @@ async function createWindow() {
   if (!fs.existsSync(KOLIBRI_HOME)) {
     mainWindow.webContents.executeJavaScript('WelcomeApp.showWelcome()', true);
   } else {
-    loadKolibriEnv(fs.existsSync(USB_CONTENT_FLAG_FILE), '').then(() => {
+    loadKolibriEnv('').then(() => {
       runKolibri();
     });
   }
@@ -294,7 +223,7 @@ app.on('ready', () => {
     if (!('pack' in data)) {
       data['pack'] = '';
     }
-    loadKolibriEnv(data.usb, data.pack).then(() => {
+    loadKolibriEnv(data.pack).then(() => {
       runKolibri();
     });
   });
@@ -303,10 +232,4 @@ app.on('ready', () => {
 app.on('window-all-closed', () => {
   app.quit();
   removePidFile();
-  if (LOCK_FILE.handler) {
-    LOCK_FILE.handler.close();
-    if (fs.existsSync(LOCK_FILE.path)) {
-      fs.rmSync(LOCK_FILE.path);
-    }
-  }
 });

--- a/kolibri-electron/src/preload.js
+++ b/kolibri-electron/src/preload.js
@@ -1,8 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('WelcomeWrapper', {
-    // Triggers the Kolibri load, configured to not use the USB and specified package
+    // Triggers the Kolibri load, configured to use specified package
     startWithNetwork: (packId) => {
-        ipcRenderer.send('load', { usb: false, pack: packId });
+        ipcRenderer.send('load', { pack: packId });
     },
 });

--- a/kolibri-electron/src/preload.js
+++ b/kolibri-electron/src/preload.js
@@ -5,8 +5,4 @@ contextBridge.exposeInMainWorld('WelcomeWrapper', {
     startWithNetwork: (packId) => {
         ipcRenderer.send('load', { usb: false, pack: packId });
     },
-    // Triggers the Kolibri load, configured to use the USB content
-    startWithUSB: () => {
-        ipcRenderer.send('load', { usb: true });
-    },
 });


### PR DESCRIPTION
Since the commit ("Welcome: Drop USB/SD option from Welcome screen") of kolibri-explore-plugin [1] drops the USB option, Endless Key app removes corresponding USB APIs accordingly.

[1]: https://github.com/endlessm/kolibri-explore-plugin

Fixes: https://github.com/endlessm/endless-key-app/issues/145