### PR TITLE
CI: Add trailer dummy files for MS store Application Payload creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -469,6 +469,19 @@ jobs:
             echo NULL > $dummy_screenshot
           }
 
+          echo "Going to create dummy trailers & their images for Application Payload creation:"
+          $xmlDoc.ProductDescription.Trailers.Trailer | ForEach-Object {
+            $dummy_trailer = "MSAppPayload/PDPs/en-us/" + $_.FileName
+            echo $dummy_trailer
+            echo NULL > $dummy_trailer
+
+            $_.Images.Image | ForEach-Object {
+              $dummy_image = "MSAppPayload/PDPs/en-us/" + $_.FileName
+              echo $dummy_image
+              echo NULL > $dummy_image
+            }
+          }
+
           New-SubmissionPackage `
             -ConfigPath "MSAppPayload/SBConfig.json" `
             -PDPRootPath "MSAppPayload/PDPs" `


### PR DESCRIPTION
A trailer of Endless Key is submitted into Microsoft store since submission #17. Therefore, the PDP xml includes the trailer information. But, its files are not downloaded by ConvertFrom-ExistingSubmission.ps1. Then, the Application Payload creation shows error:
```
Write-Error: C:\Users\runneradmin\Documents\PowerShell\Modules\StoreBroker\1.21.0\StoreBroker\PackageTool.ps1:3760 Line |
3760 |          Write-Log -Exception $_ -Level Error
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | 2023-08-10 03:46:04 : runneradmin :  Write-Log:
     | C:\Users\runneradmin\Documents\PowerShell\Modules\StoreBroker\1.21.0\StoreBroker\PackageTool.ps1:1279 Line |
     | 1279 |          Write-Log -Message $output -Level Error      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | | 2023-08-10 03:46:04 : runneradmin : Could not find media file [Endless Key.mp4] in any subdirectory of      |
     | [D:\a\endless-key-app\endless-key-app\MSAppPayload\PDPs\en-us].
```
So, we have to produce the dummy trailer files, like those Screenshot Captions. The Trailer's format in the PDP XML is described in StoreBroker's document PDP (Product Description Page) Files [1]. Each trailer has a image.

[1]: https://github.com/microsoft/StoreBroker/blob/2.1.9/Documentation/PDP.md#trailers

Fixes: https://github.com/endlessm/endless-key-app/issues/149