### PR TITLE
CI: Add additional dummy assets for MS store Application Payload creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -469,6 +469,13 @@ jobs:
             echo NULL > $dummy_screenshot
           }
 
+          echo "Going to create dummy additional assets for Application Payload creation:"
+          $xmlDoc.ProductDescription.AdditionalAssets.ChildNodes.FileName | ForEach-Object {
+            $dummy_assest = "MSAppPayload/PDPs/en-us/" + $_
+            echo $dummy_assest
+            echo NULL > $dummy_assest
+          }
+
           echo "Going to create dummy trailers & their images for Application Payload creation:"
           $xmlDoc.ProductDescription.Trailers.Trailer | ForEach-Object {
             $dummy_trailer = "MSAppPayload/PDPs/en-us/" + $_.FileName


### PR DESCRIPTION
A new additional asset of Endless Key is submitted into Microsoft store since submission #18. Therefore, the PDP xml includes the additional assets information.

But, the files are not downloaded by ConvertFrom-ExistingSubmission.ps1. Then, the Application Payload creation shows error:
```
VERBOSE: 2023-08-18 16:13:46 : runneradmin : Deleting temporary directory complete.
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | 2023-08-18 16:13:46 : runneradmin :  Write-Log:
     | C:\Users\runneradmin\Documents\PowerShell\Modules\StoreBroker\1.21.0\StoreBroker\PackageTool.ps1:1279 Line |
     | 1279 |          Write-Log -Message $output -Level Error      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | | 2023-08-18 16:13:46 : runneradmin : Could not find media file [Microsoft Superhero (1).png] in any
     | subdirectory      | of [D:\a\endless-key-app\endless-key-app\MSAppPayload\PDPs\en-us].

Error: Process completed with exit code 1.
```
So, we have to produce the dummy assets, like those Screenshot Captions.

Fixes: https://github.com/endlessm/endless-key-app/issues/152