### PR TITLE
Use released collections

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_call:
     inputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,16 +101,15 @@ jobs:
           7z x apps-bundle.zip -osrc/apps-bundle
 
       - name: Download collections manifest files
-        run: |
-          $CollectionUri = 'https://github.com/endlessm/endless-key-collections/archive/refs/heads/main.zip'
-          $CollectionTarball = 'endless-key-collections.zip'
-          Invoke-WebRequest -Uri $CollectionUri -OutFile $CollectionTarball
-          Expand-Archive -Path $CollectionTarball -DestinationPath .
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: "endlessm/endless-key-collections"
+          latest: true
+          fileName: "collections.zip"
 
-      - name: Add endless-key-collections to Kolibri's dist package
+      - name: Add collections to Kolibri's dist package
         run: |
-          mkdir src/collections
-          mv endless-key-collections-*/json/*.json src/collections
+          7z x collections.zip -osrc/collections
 
       - name: Patch Kolibri
         run: |

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ launch the Kolibri server with a minimal configuration.
     https://github.com/endlessm/kolibri-explore-plugin/releases/latest/download/apps-bundle.zip
 ```
 
- * Download endless key collections, unzip and copy the `json` folder to `collections`:
+ * Download endless key collections and unzip it in `collections`:
 ```
-    https://github.com/endlessm/endless-key-collections/archive/refs/heads/main.zip
+    https://github.com/endlessm/endless-key-collections/releases/latest/download/collections.zip
 ```
 
  * Build kolibri-electron:


### PR DESCRIPTION
endless-key-collections now generates a `collections.zip` asset for releases. Use that instead of the archive generated for the latest `main` commit. The asset is a flat zip file, which simplifies extraction.