### PR TITLE
Set device to use system language

### DIFF
--- a/src/automatic_provision.json
+++ b/src/automatic_provision.json
@@ -10,7 +10,7 @@
         "show_download_button_in_learn": true
     },
     "device_settings": {
-        "language_id": "en",
+        "language_id": null,
         "landing_page": "learn",
         "allow_guest_access": true,
         "allow_peer_unlisted_channel_import": true,


### PR DESCRIPTION
Use `null` as the device `language_id` so that it uses the system language instead of hardcoding the language to `en`. Note that this requires Kolibri 0.16.0-beta6 to handle the `null` value correctly.

Fixes: #158